### PR TITLE
Feature/key join group async

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,25 @@
+name: Go
+
+on: [ pull_request ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [ '1.19', '1.20', '1.21.x' ]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ matrix.go-version }}
+      # You can test your matrix by printing the current Go version
+      - name: Display Go version
+        run: go version
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+      - name: Unit Tests
+        run: go test -v ./tests/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,3 +23,20 @@ jobs:
         uses: actions/checkout@v2
       - name: Unit Tests
         run: go test -v ./tests/
+
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+          cache: false
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          # Require: The version of golangci-lint to use.
+          # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.
+          # When `install-mode` is `goinstall` the value can be v1.2.3, `latest`, or the hash of a commit.
+          version: v1.54

--- a/README.md
+++ b/README.md
@@ -5,3 +5,37 @@ A proof of concept flow processing library built on Go Generics, which were
 introduced in 1.18.
 
 
+## Basic Map example
+```
+func Inc(a int) int {
+	return a + 1
+}
+
+func main() {
+	in := make(chan int, 10)
+
+	wf := flame.NewWorkflow()
+	inc := flame.AddSourceChan(wf, in)
+	a := flame.AddMapper(wf, Inc)
+	a.Connect(inc)
+	b := flame.AddMapper(wf, Inc)
+	b.Connect(a)
+	out := b.GetOutput()
+
+	wf.Start()
+
+	v := []int{1, 2, 3, 4, 5}
+
+	go func() {
+		for _, n := range v {
+			in <- n
+		}
+		close(in)
+	}()
+
+	i := 0
+	for o := range out {
+        fmt.Printf("out: %s\n", o)
+    }
+}
+```

--- a/accumulate.go
+++ b/accumulate.go
@@ -26,7 +26,7 @@ func (n *AccumulateNode[K, X, Y]) GetOutput() chan KeyValue[K, Y] {
 	return m
 }
 
-func (n *AccumulateNode[K, X, Y]) Start(wf *Workflow) {
+func (n *AccumulateNode[K, X, Y]) start(wf *Workflow) {
 	wf.WaitGroup.Add(1)
 	go func() {
 		first := true

--- a/flame.go
+++ b/flame.go
@@ -1,7 +1,7 @@
 package flame
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"sync"
 
@@ -33,7 +33,7 @@ type Emitter[X any] interface {
 }
 
 type Process interface {
-	Start(wf *Workflow)
+	start(wf *Workflow)
 }
 
 func NewWorkflow() *Workflow {
@@ -43,7 +43,7 @@ func NewWorkflow() *Workflow {
 func (wf *Workflow) Start() {
 	wf.WaitGroup = &sync.WaitGroup{}
 	for i := range wf.Nodes {
-		wf.Nodes[i].Start(wf)
+		wf.Nodes[i].start(wf)
 	}
 }
 
@@ -56,7 +56,7 @@ func (wf *Workflow) Wait() {
 }
 
 func (wf *Workflow) GetTmpDir() (string, error) {
-	return ioutil.TempDir(wf.WorkDir, "flame_")
+	return os.MkdirTemp(wf.WorkDir, "flame_")
 }
 
 /**************************/
@@ -78,7 +78,7 @@ func (n *SourceChanNode[X, Y]) Connect(e Emitter[X]) {
 	//this should throw an error
 }
 
-func (n *SourceChanNode[X, Y]) Start(wf *Workflow) {
+func (n *SourceChanNode[X, Y]) start(wf *Workflow) {
 	wf.WaitGroup.Add(1)
 	go func() {
 		for x := range n.Source {
@@ -118,7 +118,7 @@ func (n *SourceNode[X, Y]) Connect(e Emitter[X]) {
 	//this should throw an error
 }
 
-func (n *SourceNode[X, Y]) Start(wf *Workflow) {
+func (n *SourceNode[X, Y]) start(wf *Workflow) {
 	wf.WaitGroup.Add(1)
 	go func() {
 		for {
@@ -163,7 +163,7 @@ func (n *SinkNode[X, Y]) Connect(e Emitter[X]) {
 	n.Input = o
 }
 
-func (n *SinkNode[X, Y]) Start(wf *Workflow) {
+func (n *SinkNode[X, Y]) start(wf *Workflow) {
 	wf.WaitGroup.Add(1)
 	go func() {
 		if n.Input != nil {

--- a/flatmap.go
+++ b/flatmap.go
@@ -16,7 +16,7 @@ func AddFlatMapper[X, Y any](w *Workflow, f func(X) []Y) Node[X, Y] {
 	return n
 }
 
-func (n *FlatMapNode[X, Y]) Start(wf *Workflow) {
+func (n *FlatMapNode[X, Y]) start(wf *Workflow) {
 	wf.WaitGroup.Add(1)
 	go func() {
 		if n.Input != nil {

--- a/flatmap_pool.go
+++ b/flatmap_pool.go
@@ -18,7 +18,7 @@ func AddFlatMapperPool[X, Y any](w *Workflow, f func(X) []Y, nthread int) Node[X
 	return n
 }
 
-func (n *FlatMapPoolNode[X, Y]) Start(wf *Workflow) {
+func (n *FlatMapPoolNode[X, Y]) start(wf *Workflow) {
 	wf.WaitGroup.Add(1)
 
 	if n.ChannelSize <= 0 {

--- a/join.go
+++ b/join.go
@@ -29,7 +29,7 @@ func (n *JoinNode[X, Y, Z]) ConnectRight(e Emitter[Y]) {
 	n.RightInput = o
 }
 
-func (n *JoinNode[X, Y, Z]) Start(wf *Workflow) {
+func (n *JoinNode[X, Y, Z]) start(wf *Workflow) {
 	wf.WaitGroup.Add(1)
 	out := make(chan Z, 10)
 	go func() {

--- a/key_join.go
+++ b/key_join.go
@@ -35,7 +35,7 @@ func (n *KeyJoinNode[K, X, Y, Z]) ConnectRight(e Emitter[KeyValue[K, Y]]) {
 	n.RightInput = o
 }
 
-func (n *KeyJoinNode[K, X, Y, Z]) Start(wf *Workflow) {
+func (n *KeyJoinNode[K, X, Y, Z]) start(wf *Workflow) {
 	wf.WaitGroup.Add(1)
 
 	wg := &sync.WaitGroup{}

--- a/key_join_group_async.go
+++ b/key_join_group_async.go
@@ -1,0 +1,91 @@
+package flame
+
+import (
+	"sync"
+
+	"golang.org/x/exp/constraints"
+)
+
+type KeyJoinGroupAsyncNode[K constraints.Ordered, X, Z any] struct {
+	Inputs  []chan KeyValue[K, X]
+	Outputs []chan KeyValue[K, Z]
+	Proc    func(K, []X) Z
+}
+
+func AddKeyJoinGroupAsync[K constraints.Ordered, X, Z any](w *Workflow, f func(K, []X) Z) *KeyJoinGroupAsyncNode[K, X, Z] {
+	n := &KeyJoinGroupAsyncNode[K, X, Z]{Proc: f, Outputs: []chan KeyValue[K, Z]{}}
+	w.Nodes = append(w.Nodes, n)
+	return n
+}
+
+func (n *KeyJoinGroupAsyncNode[K, X, Z]) Start(wf *Workflow) {
+	wf.WaitGroup.Add(1)
+
+	mut := &sync.Mutex{}
+	store := map[K][]X{}
+
+	updates := make(chan K, len(n.Inputs))
+
+	wg := &sync.WaitGroup{}
+	for i := 0; i < len(n.Inputs); i++ {
+		wg.Add(1)
+		go func(inputN int) {
+			for l := range n.Inputs[inputN] {
+				mut.Lock()
+				if v, ok := store[l.Key]; ok {
+					v[inputN] = l.Value
+				} else {
+					v := make([]X, len(n.Inputs))
+					v[inputN] = l.Value
+					store[l.Key] = v
+				}
+				mut.Unlock()
+				updates <- l.Key
+			}
+			wg.Done()
+		}(i)
+	}
+
+	go func() {
+		wg.Wait()
+		close(updates)
+	}()
+
+	go func() {
+		hits := map[K]int{}
+		for key := range updates {
+			if x, ok := hits[key]; ok {
+				x++
+				if x >= len(n.Inputs) {
+					delete(hits, key)
+					mut.Lock()
+					val := n.Proc(key, store[key])
+					delete(store, key)
+					mut.Unlock()
+					for i := range n.Outputs {
+						n.Outputs[i] <- KeyValue[K, Z]{key, val}
+					}
+				} else {
+					hits[key] = x
+				}
+			} else {
+				hits[key] = 1
+			}
+		}
+		for i := range n.Outputs {
+			close(n.Outputs[i])
+		}
+		wf.WaitGroup.Done()
+	}()
+}
+
+func (n *KeyJoinGroupAsyncNode[K, X, Z]) GetOutput() chan KeyValue[K, Z] {
+	m := make(chan KeyValue[K, Z])
+	n.Outputs = append(n.Outputs, m)
+	return m
+}
+
+func (n *KeyJoinGroupAsyncNode[K, X, Z]) Connect(e Emitter[KeyValue[K, X]]) {
+	o := e.GetOutput()
+	n.Inputs = append(n.Inputs, o)
+}

--- a/key_join_group_async.go
+++ b/key_join_group_async.go
@@ -18,7 +18,7 @@ func AddKeyJoinGroupAsync[K constraints.Ordered, X, Z any](w *Workflow, f func(K
 	return n
 }
 
-func (n *KeyJoinGroupAsyncNode[K, X, Z]) Start(wf *Workflow) {
+func (n *KeyJoinGroupAsyncNode[K, X, Z]) start(wf *Workflow) {
 	wf.WaitGroup.Add(1)
 
 	mut := &sync.Mutex{}

--- a/map.go
+++ b/map.go
@@ -1,23 +1,26 @@
 package flame
 
-
 /**************************/
 // Mapper
 /**************************/
 
+// MapNode represents a flow step that takes an input X calls a function f(X) that
+// returns Y
 type MapNode[X, Y any] struct {
 	Input   chan X
 	Outputs []chan Y
 	Proc    func(X) Y
 }
 
+// AddMapper adds a MapNode step to the workflow
 func AddMapper[X, Y any](w *Workflow, f func(X) Y) Node[X, Y] {
 	n := &MapNode[X, Y]{Proc: f, Outputs: []chan Y{}}
 	w.Nodes = append(w.Nodes, n)
 	return n
 }
 
-func (n *MapNode[X, Y]) Start(wf *Workflow) {
+// Start function called by Workflow object
+func (n *MapNode[X, Y]) start(wf *Workflow) {
 	wf.WaitGroup.Add(1)
 	go func() {
 		if n.Input != nil {
@@ -35,12 +38,15 @@ func (n *MapNode[X, Y]) Start(wf *Workflow) {
 	}()
 }
 
+// GetOutput returns a chan Y of the results of f(Y)
+// This channel must be read out or the flow will stop
 func (n *MapNode[X, Y]) GetOutput() chan Y {
 	m := make(chan Y)
 	n.Outputs = append(n.Outputs, m)
 	return m
 }
 
+// Connect sets the input X stream for f(X)
 func (n *MapNode[X, Y]) Connect(e Emitter[X]) {
 	o := e.GetOutput()
 	n.Input = o

--- a/map_pool.go
+++ b/map_pool.go
@@ -12,13 +12,15 @@ type MapPoolNode[X, Y any] struct {
 	ChannelSize int
 }
 
+// AddMapperPool adds a map step to the flow. As opposed to MapNode, MapPoolNode uses
+// a pool of N workers to process elements in parallel.
 func AddMapperPool[X, Y any](w *Workflow, f func(X) Y, nthread int) Node[X, Y] {
 	n := &MapPoolNode[X, Y]{Proc: f, Outputs: []chan Y{}, ProcCount: nthread, ChannelSize: 10}
 	w.Nodes = append(w.Nodes, n)
 	return n
 }
 
-func (n *MapPoolNode[X, Y]) Start(wf *Workflow) {
+func (n *MapPoolNode[X, Y]) start(wf *Workflow) {
 	wf.WaitGroup.Add(1)
 
 	if n.ChannelSize <= 0 {

--- a/reduce.go
+++ b/reduce.go
@@ -11,13 +11,16 @@ type ReduceNode[X, Y any] struct {
 	Proc    func(X, Y) Y
 }
 
+// AddReducer adds a reduce step to the flow. A reducer starts with y = Y_init
+// It then streams the inputs X, calling y = f(x,y). When X closes it emits the last
+// value of y once.
 func AddReducer[X, Y any](w *Workflow, f func(X, Y) Y, init Y) Node[X, Y] {
 	n := &ReduceNode[X, Y]{Proc: f, Outputs: []chan Y{}, Init: init}
 	w.Nodes = append(w.Nodes, n)
 	return n
 }
 
-func (n *ReduceNode[X, Y]) Start(wf *Workflow) {
+func (n *ReduceNode[X, Y]) start(wf *Workflow) {
 	wf.WaitGroup.Add(1)
 	go func() {
 		y := n.Init

--- a/sort.go
+++ b/sort.go
@@ -38,7 +38,7 @@ func (s *SortNode[X, Y]) Len() int {
 	return len(s.Queue)
 }
 
-func (s *SortNode[X, Y]) Start(wf *Workflow) {
+func (s *SortNode[X, Y]) start(wf *Workflow) {
 	wf.WaitGroup.Add(1)
 	go func() {
 		if s.Input != nil {

--- a/stored.go
+++ b/stored.go
@@ -72,17 +72,32 @@ func (n *ReduceKeyNode[K, X, Y]) start(wf *Workflow) {
 				//The means entries with the same user key will be stored in seperate
 				//records
 				key := bytes.Join([][]byte{[]byte(x.Key), bPos}, []byte{})
-				batch.Set(key, bSize, nil)
+				err := batch.Set(key, bSize, nil)
+				if err != nil {
+					log.Printf("Write error: %s", err)
+				}
 				curSize += len(key) + len(bSize)
 				if curSize > maxWriterBuffer {
-					batch.Commit(nil)
+					err := batch.Commit(nil)
+					if err != nil {
+						log.Printf("Commit error: %s", err)
+					}
 					batch.Reset()
 					curSize = 0
 				}
-				dump.Write(data)
-				dump.Write([]byte("\n"))
+				_, err = dump.Write(data)
+				if err != nil {
+					log.Printf("write error: %s", err)
+				}
+				_, err = dump.Write([]byte("\n"))
+				if err != nil {
+					log.Printf("write error: %s", err)
+				}
 			}
-			batch.Commit(nil)
+			err = batch.Commit(nil)
+			if err != nil {
+				log.Printf("Log error: %s", err)
+			}
 			batch.Close()
 		}
 
@@ -94,8 +109,10 @@ func (n *ReduceKeyNode[K, X, Y]) start(wf *Workflow) {
 			bPos := k[len(k)-8:]
 			dPos := binary.BigEndian.Uint64(bPos)
 			data := make([]byte, dSize)
-			dump.ReadAt(data, int64(dPos))
-			jsonChan <- KeyValue[K, []byte]{Key: K(key), Value: data}
+			_, err = dump.ReadAt(data, int64(dPos))
+			if err == nil {
+				jsonChan <- KeyValue[K, []byte]{Key: K(key), Value: data}
+			}
 		}
 		dump.Close()
 		db.Close()

--- a/stored.go
+++ b/stored.go
@@ -36,7 +36,7 @@ func AddReduceKey[K byteAble, X, Y any](w *Workflow, f func(K, X, Y) Y, init Y) 
 	return n
 }
 
-func (n *ReduceKeyNode[K, X, Y]) Start(wf *Workflow) {
+func (n *ReduceKeyNode[K, X, Y]) start(wf *Workflow) {
 	wf.WaitGroup.Add(1)
 
 	jsonChan := make(chan KeyValue[K, []byte], 10)

--- a/stream.go
+++ b/stream.go
@@ -16,7 +16,7 @@ func AddStreamer[X, Y any](w *Workflow, f func(chan X, chan Y)) Node[X, Y] {
 	return n
 }
 
-func (n *StreamNode[X, Y]) Start(wf *Workflow) {
+func (n *StreamNode[X, Y]) start(wf *Workflow) {
 	wf.WaitGroup.Add(1)
 	out := make(chan Y, 10)
 	go func() {

--- a/tests/accumulate_test.go
+++ b/tests/accumulate_test.go
@@ -23,12 +23,12 @@ func TestAccumulate(t *testing.T) {
 	wf.Start()
 
 	v := []flame.KeyValue[int, string]{
-		{1, "charles"},
-		{1, "bob"},
-		{2, "alice"},
-		{2, "dan"},
-		{3, "edward"},
-		{3, "frank"},
+		{Key: 1, Value: "charles"},
+		{Key: 1, Value: "bob"},
+		{Key: 2, Value: "alice"},
+		{Key: 2, Value: "dan"},
+		{Key: 3, Value: "edward"},
+		{Key: 3, Value: "frank"},
 	}
 
 	go func() {

--- a/tests/key_join_group_async_test.go
+++ b/tests/key_join_group_async_test.go
@@ -1,0 +1,74 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/bmeg/flame"
+)
+
+func KeyJoinGroup(k string, x []int) map[string]any {
+	out := map[string]any{}
+
+	return out
+}
+
+func TestJoinGroupKeyAsync(t *testing.T) {
+
+	inputs := make(chan flame.KeyValue[string, int], 10)
+
+	wf := flame.NewWorkflow()
+	wf.SetWorkDir("./")
+
+	in := flame.AddSourceChan(wf, inputs)
+
+	steps := []flame.Emitter[flame.KeyValue[string, int]]{}
+	for i := 0; i < 5; i++ {
+		inc := i
+		m := flame.AddMapper(wf, func(x flame.KeyValue[string, int]) flame.KeyValue[string, int] {
+			x.Value += inc
+			return x
+		})
+		m.Connect(in)
+		steps = append(steps, m)
+	}
+
+	as := flame.AddKeyJoinGroupAsync(wf, func(key string, x []int) []int {
+		return x
+	})
+
+	for _, i := range steps {
+		as.Connect(i)
+	}
+
+	fmt.Printf("Starting Workflow\n")
+	wf.Start()
+
+	v1 := []flame.KeyValue[string, int]{
+		{Key: "a", Value: 1},
+		{Key: "b", Value: 2},
+		{Key: "c", Value: 3},
+	}
+	go func() {
+		for _, n := range v1 {
+			inputs <- n
+		}
+		close(inputs)
+	}()
+
+	/*
+		results := map[string]int{
+			"a": 4,
+			"b": 10,
+			"c": 14,
+		}
+	*/
+
+	out := as.GetOutput()
+
+	for i := range out {
+		fmt.Printf("%#v\n", i)
+	}
+
+	wf.Wait()
+}

--- a/tests/keyjoin_test.go
+++ b/tests/keyjoin_test.go
@@ -34,9 +34,9 @@ func TestJoinKey(t *testing.T) {
 	wf.Start()
 
 	v1 := []flame.KeyValue[string, int]{
-		{"b", 2},
-		{"a", 1},
-		{"c", 4},
+		{Key: "b", Value: 2},
+		{Key: "a", Value: 1},
+		{Key: "c", Value: 4},
 	}
 	go func() {
 		for _, n := range v1 {
@@ -46,9 +46,9 @@ func TestJoinKey(t *testing.T) {
 	}()
 
 	v2 := []flame.KeyValue[string, int]{
-		{"c", 10},
-		{"a", 3},
-		{"b", 8},
+		{Key: "c", Value: 10},
+		{Key: "a", Value: 3},
+		{Key: "b", Value: 8},
 	}
 	go func() {
 		for _, n := range v2 {

--- a/tests/reduce_key_test.go
+++ b/tests/reduce_key_test.go
@@ -23,15 +23,15 @@ func TestReduceKey(t *testing.T) {
 	wf.Start()
 
 	v := []flame.KeyValue[string, int]{
-		{"a", 1},
-		{"a", 1},
-		{"a", 1},
-		{"b", 2},
-		{"b", 2},
-		{"b", 2},
-		{"c", 4},
-		{"c", 5},
-		{"c", 6},
+		{Key: "a", Value: 1},
+		{Key: "a", Value: 1},
+		{Key: "a", Value: 1},
+		{Key: "b", Value: 2},
+		{Key: "b", Value: 2},
+		{Key: "b", Value: 2},
+		{Key: "c", Value: 4},
+		{Key: "c", Value: 5},
+		{Key: "c", Value: 6},
 	}
 	go func() {
 		for _, n := range v {

--- a/tests/sort_test.go
+++ b/tests/sort_test.go
@@ -26,11 +26,11 @@ func TestIntSort(t *testing.T) {
 	wf.Start()
 
 	v := []flame.KeyValue[int, string]{
-		{3, "charles"},
-		{2, "bob"},
-		{1, "alice"},
-		{4, "dan"},
-		{5, "edward"},
+		{Key: 3, Value: "charles"},
+		{Key: 2, Value: "bob"},
+		{Key: 1, Value: "alice"},
+		{Key: 4, Value: "dan"},
+		{Key: 5, Value: "edward"},
 	}
 
 	go func() {
@@ -57,11 +57,11 @@ func TestStringSort(t *testing.T) {
 	wf.Start()
 
 	v := []flame.KeyValue[string, int]{
-		{"charles", 3},
-		{"bob", 2},
-		{"alice", 1},
-		{"dan", 4},
-		{"edward", 5},
+		{Key: "charles", Value: 3},
+		{Key: "bob", Value: 2},
+		{Key: "alice", Value: 1},
+		{Key: "dan", Value: 4},
+		{Key: "edward", Value: 5},
 	}
 
 	go func() {

--- a/util.go
+++ b/util.go
@@ -1,5 +1,6 @@
 package flame
 
+/*
 func allTrue(x []bool) bool {
 	for _, y := range x {
 		if !y {
@@ -8,6 +9,7 @@ func allTrue(x []bool) bool {
 	}
 	return true
 }
+*/
 
 func anyTrue(x []bool) bool {
 	for _, y := range x {


### PR DESCRIPTION
Adds new node type `KeyJoinGroupAsyncNode` for workflows. It takes multiple KeyValue input streams, and joins them by keys. It does this asynchronously, meaning that as soon it finds a key match across input channels it calls the user function. If there are duplicate keys in an input stream, the results are undetermined